### PR TITLE
Refactor: Catch Result<T, E>'s

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use crate::discovery::ConfigError::BadState;
 use crate::discovery::{JsonWebKeySet, ProviderMetadata};
 use crate::util;
 use jwt_simple::claims::NoCustomClaims;
-use jwt_simple::prelude::{Claims, JWTClaims, RSAPublicKeyLike, VerificationOptions};
+use jwt_simple::prelude::{JWTClaims, RSAPublicKeyLike, VerificationOptions};
 use jwt_simple::Error;
 use oauth2::basic::{BasicClient, BasicErrorResponse, BasicTokenResponse, BasicTokenType};
 use oauth2::{

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -77,7 +77,7 @@ impl ProviderMetadata {
         }
     }
 
-    pub fn from_bytes(bytes: Vec<u8>) -> Result<ProviderMetadata, ConfigError> {
+    pub fn from_bytes(bytes: &Vec<u8>) -> Result<ProviderMetadata, ConfigError> {
         serde_json::from_slice::<ProviderMetadata>(bytes.as_slice())
             .map_err(|err| {
                 ConfigError::Parse(err.to_string())

--- a/src/oauth_client.rs
+++ b/src/oauth_client.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use oauth2::{ClientId, ClientSecret, CsrfToken, HttpRequest, PkceCodeChallenge};
+use oauth2::{ClientId, ClientSecret, HttpRequest, PkceCodeChallenge};
 use oauth2::basic::BasicClient;
 use time::Duration;
 use url::{Url, ParseError};
@@ -234,12 +234,9 @@ mod tests {
 
     use super::*;
     use crate::config::{FilterConfig};
-    use time::{NumericalDuration, NumericalStdDurationShort};
     use crate::discovery::{JsonWebKeySet, ProviderMetadata};
-    use jsonwebkey::{JsonWebKey, Key, RsaPublic, PublicExponent, ByteVec};
-    use jwt_simple::prelude::{RS256PublicKey, RS256KeyPair, RSAKeyPairLike, JWTClaims, Claims};
-    use jwt_simple::claims::NoCustomClaims;
-    use jsonwebkey::Algorithm::RS256;
+    use jsonwebkey::{Key, RsaPublic, PublicExponent, ByteVec};
+    use jwt_simple::prelude::{RS256KeyPair, RSAKeyPairLike, Claims};
 
     fn test_config_extra(scopes: Vec<String>) -> FilterConfig {
         FilterConfig::oauth(
@@ -337,12 +334,17 @@ mod tests {
     }
 
     fn test_request() -> Request {
-        Request::new( vec![
+        match Request::new( vec![
             ("random_header".to_string(), "value".to_string()),
             ("x-forwarded-proto".to_string(), "http".to_string()),
             (":authority".to_string(), "localhost".to_string()),
             (":path".to_string(), "/test-path".to_string())
-        ]).unwrap()
+        ]) {
+            Ok(request) => request,
+            Err(e) => {
+                panic!("Unable to generate generate oauth test request: {:?}", e)
+            },
+        }
     }
 
     fn test_callback_request() -> Request {
@@ -371,7 +373,7 @@ mod tests {
     }
 
     fn test_successful_token_response(keypair: RS256KeyPair, ) -> TokenResponse {
-        let mut claims =
+        let claims =
             Claims::create(jwt_simple::prelude::Duration::from_hours(1));
         let claims = claims.with_issuer("https://issuer")
             .with_audience("myclient");

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, SystemTimeError};
 use serde::{Serialize, Deserialize};
-use oauth2::http::{HeaderMap, HeaderValue};
+use oauth2::http::HeaderMap;
 use oauth2::http::header::{AUTHORIZATION, SET_COOKIE};
 use cookie::CookieBuilder;
 use crate::util;


### PR DESCRIPTION
Avoid thrown exceptions/errors slamming the process in the face at run-time.

Also:
- Remove another unused `mut`
- Remove more unused imports
- Converted some function parameters into borrows since they didn't need
   to own the parameter value.
- Caught error situation when `:path` is not present in headers, inside
   `fn oauth_client_types::request_url`